### PR TITLE
restrain scipy version to be <1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,3 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "neo",
     "matplotlib",
     "efel",
-    "scipy",
+    "scipy<1.15",
     "h5py",
     "igor2",
 ]


### PR DESCRIPTION
scipy.ndimage.median_filter is bugg since scipy 1.15. We should wait for this error to be solved before allowing latest scipy to be used: https://github.com/scipy/scipy/issues/22250

I have updated PyPi so that it trusts this repo, so we don't need the secrets in the github action anymore