### PR TITLE
Add protocol filtering to TRTNWBReader and log missing protocols

### DIFF
--- a/bluepyefe/extract.py
+++ b/bluepyefe/extract.py
@@ -451,6 +451,17 @@ def group_efeatures(
         efel_settings=efel_settings,
     )
 
+    # Check if any protocol is missing in all cells
+    for protocol in protocols:
+        found = any(
+            cell.get_recordings_by_protocol_name(protocol.name)
+            for cell in cells
+        )
+        if not found:
+            logger.warning(
+                f"Protocol '{protocol.name}' not found in any cell recordings."
+            )
+
     for protocol in protocols:
         for cell in cells:
 

--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -277,6 +277,16 @@ class TRTNWBReader(NWBReader):
             data (list of dict): list of traces
         """
         data = []
+
+        # Only return data if target_protocols is None or includes "step"
+        if self.target_protocols:
+            allowed = [p.lower() for p in self.target_protocols]
+            if not any(proto in allowed for proto in ["step"]):
+                logger.warning(
+                    f"TRTNWBReader only supports 'step' protocols, but requested: {self.target_protocols}. Skipping."
+                )
+                return []
+
         # possible paths in content:
         # /acquisition/index_00
         # or /acquisition/index_000

--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -281,7 +281,7 @@ class TRTNWBReader(NWBReader):
         # Only return data if target_protocols is None or includes "step"
         if self.target_protocols:
             allowed = [p.lower() for p in self.target_protocols]
-            if not any(proto in allowed for proto in ["step"]):
+            if "step" not in allowed:
                 logger.warning(
                     f"TRTNWBReader only supports 'step' protocols, but requested: {self.target_protocols}. Skipping."
                 )


### PR DESCRIPTION
- Skip trace extraction in TRTNWBReader if requested protocols is not a 'step'
- Log a warning when a requested protocol is not found in any cell recordings
