### PR TITLE
Add NWB inspection API with automatic reader detection

### DIFF
--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -414,6 +414,12 @@ class VUNWBReader(NWBReader):
         self.repetition = repetition
         self.in_data = in_data
 
+    def _get_target_protocols(self):
+        target_protocols = self.in_data.get("protocol_name", self.target_protocols)
+        if isinstance(target_protocols, str):
+            return [target_protocols]
+        return target_protocols
+
     def read(self):
         """ Read and format the content of the NWB file
         Returns:
@@ -421,6 +427,7 @@ class VUNWBReader(NWBReader):
         """
 
         data = []
+        target_protocols = self._get_target_protocols()
         for sweep_name, current_sweep in list(self.content["stimulus"]["presentation"].items()):
 
             stimulus_description = None
@@ -433,7 +440,7 @@ class VUNWBReader(NWBReader):
                 continue
             translated_name = PROTOCOL_VU_TO_BBP[stimulus_description]
 
-            if translated_name != self.in_data["protocol_name"]:
+            if translated_name not in target_protocols:
                 continue
 
             voltage_sweep_name = sweep_name.replace("DA", "AD")

--- a/bluepyefe/nwbreader.py
+++ b/bluepyefe/nwbreader.py
@@ -11,6 +11,18 @@ PROTOCOL_VU_TO_BBP = {
 }
 
 
+def _normalize_scala_protocol_name(protocol_name):
+    """Normalize protocol labels using the Scala reader rules."""
+    if isinstance(protocol_name, bytes):
+        protocol_name = protocol_name.decode("UTF-8")
+    protocol_name_lower = protocol_name.lower()
+    if protocol_name_lower == "na" or (
+        "step" in protocol_name_lower and protocol_name_lower != "genericstep"
+    ):
+        return "Step"
+    return protocol_name
+
+
 class NWBReader:
     def __init__(self, content, target_protocols, repetition=None, v_file=None):
         """ Init
@@ -132,8 +144,7 @@ class ScalaNWBReader(NWBReader):
                 logger.warning(f'Could not find "stimulus_description" attribute for {sweep}, Setting it as "Step"')
                 protocol_name = "Step"
 
-            if ("na" == protocol_name.lower()) or ("step" in protocol_name.lower() and "genericstep" != protocol_name.lower()):
-                protocol_name = "Step"
+            protocol_name = _normalize_scala_protocol_name(protocol_name)
 
             if (
                 self.target_protocols and

--- a/bluepyefe/reader.py
+++ b/bluepyefe/reader.py
@@ -33,6 +33,7 @@ from .nwbreader import (
     AIBSNWBReader,
     TRTNWBReader,
     VUNWBReader,
+    _normalize_scala_protocol_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -258,15 +259,6 @@ def _create_nwb_reader(reader_class, content, target_protocols, in_data):
     if reader_class is TRTNWBReader:
         return reader_class(content, target_protocols, repetition=None)
     return reader_class(content, target_protocols, repetition=in_data.get("repetition", None))
-
-
-def _normalize_scala_protocol_name(protocol_name):
-    """Normalize protocol labels using the Scala reader rules."""
-    if protocol_name.lower() == "na" or (
-        "step" in protocol_name.lower() and protocol_name.lower() != "genericstep"
-    ):
-        return "Step"
-    return protocol_name
 
 
 def _get_nwb_protocols(content, reader_class):

--- a/bluepyefe/reader.py
+++ b/bluepyefe/reader.py
@@ -26,9 +26,20 @@ from neo import io
 import os
 
 from . import igorpy
-from .nwbreader import BBPNWBReader, ScalaNWBReader, AIBSNWBReader, TRTNWBReader, VUNWBReader
+from .nwbreader import (
+    PROTOCOL_VU_TO_BBP,
+    BBPNWBReader,
+    ScalaNWBReader,
+    AIBSNWBReader,
+    TRTNWBReader,
+    VUNWBReader,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class NWBInspectionError(RuntimeError):
+    """Raised when an NWB file cannot be inspected by a supported reader."""
 
 
 def _check_metadata(metadata, reader_name, required_entries=[]):
@@ -178,6 +189,178 @@ def read_matlab(in_data):
     return data
 
 
+def _decode_nwb_value(value):
+    """Convert NWB metadata values to plain Python objects."""
+    if isinstance(value, bytes):
+        return value.decode("UTF-8")
+    if isinstance(value, h5py.Reference):
+        return str(value)
+    if isinstance(value, numpy.ndarray):
+        if value.ndim == 0:
+            return _decode_nwb_value(value.item())
+        return [_decode_nwb_value(item) for item in value.tolist()]
+    if isinstance(value, numpy.generic):
+        return _decode_nwb_value(value.item())
+    return value
+
+
+def _unique(values):
+    """Return values in their original order without duplicates."""
+    return list(dict.fromkeys(values))
+
+
+def _get_vu_stimulus_description(current_sweep):
+    """Return the protocol description stored by VU NWB files."""
+    try:
+        return _decode_nwb_value(current_sweep.attrs["stimulus_description"])
+    except KeyError:
+        return _decode_nwb_value(current_sweep["stimulus_description"][()][0])
+
+
+def _is_vu_nwb(content):
+    """Return whether content uses paired VU DA/AD sweeps."""
+    voltage_sweeps = content["acquisition"].get("timeseries", content["acquisition"])
+    return any(
+        (name.endswith("DA") or "DA" in name) and name.replace("DA", "AD") in voltage_sweeps
+        for name in content.get("stimulus", {}).get("presentation", {}).keys()
+    )
+
+
+def _get_nwb_reader_class(content):
+    """Select the NWB reader class for an opened NWB file."""
+    if "data_organization" in content:
+        return BBPNWBReader
+    if _is_vu_nwb(content):
+        return VUNWBReader
+    if "timeseries" in content["acquisition"].keys():
+        return AIBSNWBReader
+    if next(iter(content["acquisition"]), "")[:6].lower() == "index_":
+        return TRTNWBReader
+    return ScalaNWBReader
+
+
+def _create_nwb_reader(reader_class, content, target_protocols, in_data):
+    """Create an NWB reader while preserving reader-specific arguments."""
+    if reader_class is BBPNWBReader:
+        return reader_class(
+            content=content,
+            target_protocols=target_protocols,
+            v_file=in_data.get("v_file", None),
+            repetition=in_data.get("repetition", None),
+        )
+    if reader_class is VUNWBReader:
+        return reader_class(
+            content=content,
+            target_protocols=target_protocols,
+            in_data=in_data,
+            repetition=in_data.get("repetition", None),
+        )
+    if reader_class is TRTNWBReader:
+        return reader_class(content, target_protocols, repetition=None)
+    return reader_class(content, target_protocols, repetition=in_data.get("repetition", None))
+
+
+def _normalize_scala_protocol_name(protocol_name):
+    """Normalize protocol labels using the Scala reader rules."""
+    if protocol_name.lower() == "na" or (
+        "step" in protocol_name.lower() and protocol_name.lower() != "genericstep"
+    ):
+        return "Step"
+    return protocol_name
+
+
+def _get_nwb_protocols(content, reader_class):
+    """Return protocols exposed by an opened NWB file."""
+    if reader_class is BBPNWBReader:
+        return _unique(
+            protocol
+            for cell in content["data_organization"].values()
+            for protocol in cell.keys()
+        )
+    if reader_class is VUNWBReader:
+        return _unique(
+            PROTOCOL_VU_TO_BBP[description]
+            for current_sweep in content["stimulus"]["presentation"].values()
+            if (description := _get_vu_stimulus_description(current_sweep))
+            in PROTOCOL_VU_TO_BBP
+        )
+    if reader_class is AIBSNWBReader:
+        return _unique(
+            _decode_nwb_value(sweep["aibs_stimulus_name"][()])
+            for sweep in content["acquisition"]["timeseries"].values()
+        )
+    if reader_class is TRTNWBReader:
+        return ["Step"]
+    return _unique(
+        _normalize_scala_protocol_name(
+            _decode_nwb_value(sweep.attrs.get("stimulus_description", "Step"))
+        )
+        for sweep in content["acquisition"].values()
+    )
+
+
+def _get_nwb_metadata(content):
+    """Return lightweight file-level metadata from an opened NWB file."""
+    metadata = {
+        key: _decode_nwb_value(value)
+        for key, value in content.attrs.items()
+    }
+    for key in (
+        "identifier",
+        "session_description",
+        "session_start_time",
+        "file_create_date",
+        "timestamps_reference_time",
+    ):
+        if key in content:
+            metadata[key] = _decode_nwb_value(content[key][()])
+    return metadata
+
+
+def inspect_nwb(filepath, protocol_names=None, repetition=None, v_file=None):
+    """Inspect an NWB file and return its reader, protocols, traces, and metadata."""
+    try:
+        with h5py.File(filepath, "r") as content:
+            reader_class = _get_nwb_reader_class(content)
+            protocols = _get_nwb_protocols(content, reader_class)
+            target_protocols = protocol_names or protocols
+            if isinstance(target_protocols, str):
+                target_protocols = [target_protocols]
+
+            in_data = {
+                "filepath": filepath,
+                "protocol_name": target_protocols,
+                "repetition": repetition,
+                "v_file": v_file,
+            }
+            if reader_class is VUNWBReader:
+                traces = []
+                for protocol_name in target_protocols:
+                    in_data["protocol_name"] = protocol_name
+                    reader = _create_nwb_reader(
+                        reader_class, content, [protocol_name], in_data
+                    )
+                    traces.extend(reader.read())
+            else:
+                reader = _create_nwb_reader(reader_class, content, target_protocols, in_data)
+                traces = reader.read()
+
+            if not traces:
+                raise NWBInspectionError(
+                    f"{reader_class.__name__} could not parse any traces from the NWB file."
+                )
+            return {
+                "reader": reader_class.__name__,
+                "protocols": protocols,
+                "traces": traces,
+                "metadata": _get_nwb_metadata(content),
+            }
+    except NWBInspectionError:
+        raise
+    except (KeyError, OSError, TypeError, ValueError) as exc:
+        raise NWBInspectionError(f"Unable to inspect NWB file: {exc}") from exc
+
+
 def nwb_reader(in_data):
     """Reader for .nwb
 
@@ -204,48 +387,8 @@ def nwb_reader(in_data):
         target_protocols = [target_protocols]
 
     with h5py.File(in_data["filepath"], "r") as content:
-        if "data_organization" in content:
-            # For data from BBP / LNMC lab from EPFL
-            reader = BBPNWBReader(
-                content=content,
-                target_protocols=target_protocols,
-                v_file=in_data.get("v_file", None),
-                repetition=in_data.get("repetition", None),
-            )
-
-        elif in_data.get("protocol_name") and any(
-            (name.endswith("DA") or "DA" in name) and
-            (
-                name.replace("DA", "AD")
-                in (content["acquisition"].get("timeseries", content["acquisition"]))
-            )
-            for name in content.get("stimulus", {}).get("presentation", {}).keys()
-        ):
-            # For VU data (DA/AD paired sweeps); requires protocol_name
-            reader = VUNWBReader(
-                content=content,
-                target_protocols=target_protocols,
-                in_data=in_data,
-                repetition=in_data.get("repetition", None),
-            )
-
-        elif "timeseries" in content["acquisition"].keys():
-            # For data from the Allen Institute
-            reader = AIBSNWBReader(content, target_protocols)
-
-        elif next(iter(content["acquisition"]))[:6].lower() == "index_":
-            # For data from Derek Howard
-            # (An in vitro whole-cell electrophysiology dataset of human cortical neurons)
-            reader = TRTNWBReader(content, target_protocols, repetition=None)
-
-        else:
-            # For other data, such as data used in
-            # 'Phenotypic variation of transcriptomic cell types in mouse motor cortex'
-            # by Frederico Scala et al.
-            reader = ScalaNWBReader(
-                content, target_protocols, repetition=in_data.get("repetition", None)
-            )
-
+        reader_class = _get_nwb_reader_class(content)
+        reader = _create_nwb_reader(reader_class, content, target_protocols, in_data)
         data = reader.read()
 
     return data

--- a/bluepyefe/reader.py
+++ b/bluepyefe/reader.py
@@ -211,7 +211,7 @@ def _unique(values):
 
 
 def _get_vu_stimulus_description(current_sweep):
-    """Return the protocol description stored by VU NWB files."""
+    """Return the VU protocol description from either supported NWB location."""
     try:
         return _decode_nwb_value(current_sweep.attrs["stimulus_description"])
     except KeyError:
@@ -219,16 +219,26 @@ def _get_vu_stimulus_description(current_sweep):
 
 
 def _is_vu_nwb(content):
-    """Return whether content uses paired VU DA/AD sweeps."""
+    """Return whether content looks like a VU NWB file.
+
+    VU sweep names use DA/AD channel markers:
+    - DA: digital-to-analog output channel for the commanded stimulus.
+    - AD: analog-to-digital input channel for the recorded response.
+
+    A stimulus sweep under /stimulus/presentation with "DA" in its name
+    should have a corresponding acquisition sweep with "DA" replaced by "AD".
+    """
     voltage_sweeps = content["acquisition"].get("timeseries", content["acquisition"])
-    return any(
-        (name.endswith("DA") or "DA" in name) and name.replace("DA", "AD") in voltage_sweeps
-        for name in content.get("stimulus", {}).get("presentation", {}).keys()
-    )
+    for current_sweep_name in content.get("stimulus", {}).get("presentation", {}):
+        if "DA" not in current_sweep_name:
+            continue
+        if current_sweep_name.replace("DA", "AD") in voltage_sweeps:
+            return True
+    return False
 
 
 def _get_nwb_reader_class(content):
-    """Select the NWB reader class for an opened NWB file."""
+    """Select the NWB reader class from the NWB file layout."""
     if "data_organization" in content:
         return BBPNWBReader
     if _is_vu_nwb(content):
@@ -258,6 +268,8 @@ def _create_nwb_reader(reader_class, content, target_protocols, in_data):
         )
     if reader_class is TRTNWBReader:
         return reader_class(content, target_protocols, repetition=None)
+    if reader_class is AIBSNWBReader:
+        return reader_class(content, target_protocols)
     return reader_class(content, target_protocols, repetition=in_data.get("repetition", None))
 
 
@@ -325,17 +337,8 @@ def inspect_nwb(filepath, protocol_names=None, repetition=None, v_file=None):
                 "repetition": repetition,
                 "v_file": v_file,
             }
-            if reader_class is VUNWBReader:
-                traces = []
-                for protocol_name in target_protocols:
-                    in_data["protocol_name"] = protocol_name
-                    reader = _create_nwb_reader(
-                        reader_class, content, [protocol_name], in_data
-                    )
-                    traces.extend(reader.read())
-            else:
-                reader = _create_nwb_reader(reader_class, content, target_protocols, in_data)
-                traces = reader.read()
+            reader = _create_nwb_reader(reader_class, content, target_protocols, in_data)
+            traces = reader.read()
 
             if not traces:
                 raise NWBInspectionError(

--- a/tests/test_nwbreader.py
+++ b/tests/test_nwbreader.py
@@ -271,6 +271,30 @@ def test_scala_nwbreader_filters_protocol():
     assert out == []
 
 
+def test_scala_nwbreader_decodes_bytes_protocol():
+    content = make_scala_content(protocol=b"GenericStep")
+    reader = ScalaNWBReader(content, target_protocols=["GenericStep"])
+
+    assert len(reader.read()) == 1
+
+
+def test_scala_nwbreader_normalizes_na_protocol():
+    content = make_scala_content(protocol="NA")
+    reader = ScalaNWBReader(content, target_protocols=["Step"])
+
+    assert len(reader.read()) == 1
+    assert _get_nwb_protocols(content, ScalaNWBReader) == ["Step"]
+
+
+def test_scala_nwbreader_defaults_missing_protocol_to_step():
+    content = make_scala_content()
+    content["acquisition"]["VoltageSeries_0001"].attrs = {}
+    reader = ScalaNWBReader(content, target_protocols=["Step"])
+
+    assert len(reader.read()) == 1
+    assert _get_nwb_protocols(content, ScalaNWBReader) == ["Step"]
+
+
 def test_nwb_inspection_detects_scala_layout():
     content = make_scala_content(protocol="GenericStep")
     reader_class = _get_nwb_reader_class(content)

--- a/tests/test_nwbreader.py
+++ b/tests/test_nwbreader.py
@@ -1,10 +1,17 @@
 """bluepyefe.nwbreader tests"""
+import json
 import unittest
 from pathlib import Path
 import numpy as np
 import pytest
 
-from bluepyefe.reader import nwb_reader
+from bluepyefe.reader import (
+    NWBInspectionError,
+    _get_nwb_protocols,
+    _get_nwb_reader_class,
+    inspect_nwb,
+    nwb_reader,
+)
 from bluepyefe.nwbreader import (
     NWBReader, AIBSNWBReader, ScalaNWBReader, BBPNWBReader, TRTNWBReader, VUNWBReader
 )
@@ -59,6 +66,44 @@ class TestNWBReaders(unittest.TestCase):
             self.assertIn('i_unit', entry)
             self.assertIn('v_unit', entry)
             self.assertIn('t_unit', entry)
+
+
+def test_inspect_nwb_discovers_bbp_protocols_and_metadata():
+    result = inspect_nwb('./tests/exp_data/hippocampus-portal/99111002.nwb')
+
+    assert result["reader"] == "BBPNWBReader"
+    assert result["protocols"] == ["Step"]
+    assert len(result["traces"]) == 16
+    assert result["metadata"]["nwb_version"] == "2.4.0"
+    assert result["metadata"]["identifier"] == "99111002"
+    assert result["metadata"]["session_description"] == "UCL"
+    json.dumps(result["metadata"])
+
+
+def test_inspect_nwb_filters_protocols():
+    result = inspect_nwb(
+        './tests/exp_data/hippocampus-portal/99111002.nwb',
+        protocol_names=["Step"],
+    )
+
+    assert len(result["traces"]) == 16
+
+
+def test_inspect_nwb_raises_for_missing_protocol():
+    with pytest.raises(NWBInspectionError, match="could not parse any traces"):
+        inspect_nwb(
+            './tests/exp_data/hippocampus-portal/99111002.nwb',
+            protocol_names=["Missing"],
+        )
+
+
+def test_inspect_nwb_raises_for_invalid_file(tmp_path):
+    filepath = tmp_path / "invalid.nwb"
+    filepath.write_text("not an NWB file")
+
+    with pytest.raises(NWBInspectionError, match="Unable to inspect NWB file"):
+        inspect_nwb(filepath)
+
 
 @pytest.fixture
 def dummy_voltage():
@@ -122,6 +167,13 @@ def test_aibs_nwbreader_read(dummy_content):
     assert "voltage" in data[0]
     assert "current" in data[0]
 
+
+def test_nwb_inspection_detects_aibs_layout(dummy_content):
+    reader_class = _get_nwb_reader_class(dummy_content)
+
+    assert reader_class is AIBSNWBReader
+    assert _get_nwb_protocols(dummy_content, reader_class) == ["Step"]
+
 def make_vu_content_for_step(bias_pA=0.0, with_nans=False):
     # Voltage/data
     voltage_ds = DummyDS(
@@ -167,6 +219,14 @@ def test_vunwbreader_protocol_filter_excludes_non_matching():
     traces = reader.read()
     assert traces == []
 
+
+def test_nwb_inspection_detects_vu_layout():
+    content = make_vu_content_for_step()
+    reader_class = _get_nwb_reader_class(content)
+
+    assert reader_class is VUNWBReader
+    assert _get_nwb_protocols(content, reader_class) == ["Step"]
+
 def make_scala_content(protocol="Step", repetition=None):
     acq = {}
     stim = {"presentation": {}}
@@ -209,6 +269,14 @@ def test_scala_nwbreader_filters_protocol():
     reader = ScalaNWBReader(content, target_protocols=["Step"])
     out = reader.read()
     assert out == []
+
+
+def test_nwb_inspection_detects_scala_layout():
+    content = make_scala_content(protocol="GenericStep")
+    reader_class = _get_nwb_reader_class(content)
+
+    assert reader_class is ScalaNWBReader
+    assert _get_nwb_protocols(content, reader_class) == ["GenericStep"]
 
 def make_bbp_content(ecode="Step", reps=(1,)):
     # data_organization -> per cell -> ecode -> "repetition X" -> sweep -> traces
@@ -290,3 +358,11 @@ def test_trt_reader_corrects_units():
     assert tr["dt"] == 0.0001
     assert len(tr["voltage"]) == 4
     assert len(tr["current"]) == 4
+
+
+def test_nwb_inspection_detects_trt_layout():
+    content = make_trt_content_misaligned_units()
+    reader_class = _get_nwb_reader_class(content)
+
+    assert reader_class is TRTNWBReader
+    assert _get_nwb_protocols(content, reader_class) == ["Step"]

--- a/tests/test_nwbreader.py
+++ b/tests/test_nwbreader.py
@@ -174,7 +174,9 @@ def test_nwb_inspection_detects_aibs_layout(dummy_content):
     assert reader_class is AIBSNWBReader
     assert _get_nwb_protocols(dummy_content, reader_class) == ["Step"]
 
-def make_vu_content_for_step(bias_pA=0.0, with_nans=False):
+def make_vu_content_for_step(
+    bias_pA=0.0, with_nans=False, stimulus_description_in_attrs=True
+):
     # Voltage/data
     voltage_ds = DummyDS(
         [1, 2, 3, 4],
@@ -186,14 +188,18 @@ def make_vu_content_for_step(bias_pA=0.0, with_nans=False):
         current_vals[-1] = np.nan
     current_ds = DummyDS(current_vals, {"conversion": 1.0, "unit": "pA"})
     start_time_ds = DummyDS([0.0], {"rate": 10000, "unit": "s"})
+    sweep_children = {"data": current_ds}
+    sweep_attrs = {}
+    if stimulus_description_in_attrs:
+        sweep_attrs["stimulus_description"] = "CCSteps_DA_0"
+    else:
+        sweep_children["stimulus_description"] = DummyDS([b"CCSteps_DA_0"], {})
+
     # Group layout
     content = {
         "stimulus": {
             "presentation": {
-                "sweepDA": DummyGroup(
-                    {"data": current_ds},
-                    attrs={"stimulus_description": "CCSteps_DA_0"},
-                ),
+                "sweepDA": DummyGroup(sweep_children, attrs=sweep_attrs),
             }
         },
         "acquisition": {
@@ -202,7 +208,7 @@ def make_vu_content_for_step(bias_pA=0.0, with_nans=False):
                     {
                         "data": voltage_ds,
                         "starting_time": start_time_ds,
-                        "bias_current": DummyDS([bias_pA * 1e-12], {}),  # stored in A, code multiplies by 1e12 to pA
+                        "bias_current": DummyDS(bias_pA * 1e-12, {}),
                     },
                     attrs={},
                 ),
@@ -220,12 +226,33 @@ def test_vunwbreader_protocol_filter_excludes_non_matching():
     assert traces == []
 
 
+def test_vunwbreader_accepts_protocol_list():
+    content = make_vu_content_for_step()
+    in_data = {"protocol_name": ["IV", "Step"]}
+    reader = VUNWBReader(content, target_protocols=["IV", "Step"], in_data=in_data)
+
+    assert len(reader.read()) == 1
+
+
 def test_nwb_inspection_detects_vu_layout():
     content = make_vu_content_for_step()
     reader_class = _get_nwb_reader_class(content)
 
     assert reader_class is VUNWBReader
     assert _get_nwb_protocols(content, reader_class) == ["Step"]
+
+
+def test_nwb_inspection_reads_vu_protocol_from_dataset():
+    content = make_vu_content_for_step(stimulus_description_in_attrs=False)
+    reader = VUNWBReader(
+        content,
+        target_protocols=["Step"],
+        in_data={"protocol_name": "Step"},
+    )
+
+    assert _get_nwb_protocols(content, VUNWBReader) == ["Step"]
+    assert len(reader.read()) == 1
+
 
 def make_scala_content(protocol="Step", repetition=None):
     acq = {}


### PR DESCRIPTION
## Summary

Add a public `inspect_nwb()` API for parsing and inspecting NWB files without requiring callers to know the file layout or protocol names in advance.

## Changes

- Add `inspect_nwb()` to automatically:
  - detect the appropriate NWB reader
  - discover available protocols
  - parse all traces by default
  - return the selected reader name
  - return lightweight file-level metadata
- Add `NWBInspectionError` for unsupported, invalid, or unparseable NWB files.
- Refactor `nwb_reader()` to reuse the shared reader-selection logic while preserving its existing interface.
- Support BBP, VU, AIBS, TRT, and Scala NWB layouts.
- Add tests for protocol discovery, metadata extraction, protocol filtering, invalid files, missing protocols, and layout detection.

## Example

```python
from bluepyefe.reader import inspect_nwb

result = inspect_nwb("recording.nwb")